### PR TITLE
Adding changes to numeric types section

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1095,30 +1095,354 @@
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-ecmascript-language-types-number-type">
-      <h1>The Number Type</h1>
-      <p>The Number type has exactly 18437736874454810627 (that is, <emu-eqn>2<sup>64</sup> - 2<sup>53</sup> + 3</emu-eqn>) values, representing the double-precision 64-bit binary format IEEE 754-2008 values as specified in the IEEE Standard for Floating-Point Arithmetic, except that the 9007199254740990 (that is, <emu-eqn>2<sup>53</sup> - 2</emu-eqn>) distinct &ldquo;Not-a-Number&rdquo; values of the IEEE Standard are represented in ECMAScript as a single special *NaN* value. (Note that the *NaN* value is produced by the program expression `NaN`.) In some implementations, external code might be able to detect a difference between various Not-a-Number values, but such behaviour is implementation-dependent; to ECMAScript code, all *NaN* values are indistinguishable from each other.</p>
+    <emu-clause id="sec-numeric-types">
+      <h1>Numeric Types</h1>
+      <p>ECMAScript has two built-in numeric types: Number and BigInt. In this specification, every numeric type _T_ contains a multiplicative identity value denoted _T_::unit. The specification types also have the following abstract operations, likewise denoted _T_::<i>op</i> for a given operation with specification name <i>op</i>. Unless noted otherwise, argument and result types are all _T_.</p>
+      <emu-table id="table-numeric-type-ops" caption="Numeric Type Operations">
+        <table>
+          <tbody>
+          <tr>
+            <th>
+              Invocation Synopsis
+            </th>
+            <th>
+              Value and Purpose
+            </th>
+          </tr>
+          <tr>
+            <td>
+              _T_::unaryMinus(x)
+            </td>
+            <td>
+              A specification function invoked when applying the unary minus operator. Called by the semantics of the <emu-xref href="#sec-unary-minus-operator">unary - operator</emu-xref>.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              _T_::bitwiseNOT(x)
+            </td>
+            <td>
+              A specification function invoked when applying the bitwise NOT operator. Called by the semantics of the <emu-xref href="#sec-bitwise-not-operator">bitwise NOT operator</emu-xref> for `~x`.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              _T_::exponentiate(x,&nbsp;y)
+            </td>
+            <td>
+              A specification function invoked when applying the exponentiation operator. Called by the semantics of the <emu-xref href="#sec-exp-operator">exponentiation operator</emu-xref> for `x ** y`.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              _T_::multiply(x,&nbsp;y)
+            </td>
+            <td>
+              A specification function invoked when applying the multiplication operator. Called by the semantics of the <emu-xref href="#sec-applying-the-mul-operator">`*` operator</emu-xref> for `x * y`.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              _T_::divide(x,&nbsp;y)
+            </td>
+            <td>
+              A specification function invoked when applying the division operator. Called by the semantics of the <emu-xref href="#sec-applying-the-div-operator">`/` operator</emu-xref> for `x / y`.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              _T_::remainder(x,&nbsp;y)
+            </td>
+            <td>
+              A specification function invoked when applying the truncating remainder ("mod") operator. Called by the semantics of the <emu-xref href="#sec-applying-the-mod-operator">`%` operator</emu-xref> for `x % y`.
+              <emu-todo>Revisit this name, as Number::remainder explicitly doesn't do the IEEE 754 remainder operation. However, modulo also seems problematic. (<a href="https://github.com/tc39/proposal-bigint/issues/37">issue</a>)</emu-todo>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              _T_::add(x,&nbsp;y)
+            </td>
+            <td>
+              A specification function invoked when applying the addition operator. Called by the semantics of the <emu-xref href="#sec-addition-operator-plus">`+` operator</emu-xref> for `x + y`.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              _T_::subtract(x,&nbsp;y)
+            </td>
+            <td>
+              A specification function invoked when applying the subtraction operator. Called by the semantics of the <emu-xref href="#sec-subtraction-operator-minus">`-` operator</emu-xref> for `x - y`.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              _T_::leftShift(x,&nbsp;y)
+            </td>
+            <td>
+              A specification function invoked when applying the left shift operator to two operands, both of type _T_. Called by the semantics of the <emu-xref href="#sec-left-shift-operator">`<<` operator</emu-xref> for `x << y`.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              _T_::signedRightShift(x,&nbsp;y)
+            </td>
+            <td>
+              A specification function invoked when applying the right shift operator to two operands, both of type _T_. Called by the semantics of the <emu-xref href="#sec-signed-right-shift-operator">`>>` operator</emu-xref> for `x >> y`.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              _T_::unsignedRightShift(x,&nbsp;y)
+            </td>
+            <td>
+              A specification function invoked when applying the right shift operator to two operands, both of type _T_. Called by the semantics of the <emu-xref href="#sec-unsigned-right-shift-operator">`>>>` operator</emu-xref> for `x >>> y`.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              _T_::lessThan(x,&nbsp;y)
+            </td>
+            <td>
+              A specification function invoked when applying one of the four partial-order <emu-xref href="#sec-relational-operators">relational operators</emu-xref>. The return value must be *false*, *true*, or *undefined* (for unordered inputs). Called by the <emu-xref href="#sec-abstract-relational-comparison">Abstract Relational Comparison</emu-xref> algorithm for `x < y`, `x > y`, `x <= y`, and `x >= y`.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              _T_::equal(x,&nbsp;y)
+            </td>
+            <td>
+              A specification function invoked when applying <emu-xref href="#sec-equality-operators">equality operators</emu-xref>. The return value must be *false* or *true*. Called by the <emu-xref href="#sec-strict-equality-comparison">Strict Equality Comparison</emu-xref> algorithm for `x == y`, `x != y`, `x === y`, and `x !== y`.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              _T_::sameValue(x,&nbsp;y)
+            </td>
+            <td>
+              A specification function invoked when applying <emu-xref href="#sec-samevalue">abstract operation SameValue</emu-xref>. The return value must be *false* or *true*. Called from Object internal methods to test exact value equality. May not throw an exception.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              _T_::sameValueZero(x,&nbsp;y)
+            </td>
+            <td>
+              A specification function invoked when applying <emu-xref href="#sec-samevaluezero">abstract operation SameValueZero</emu-xref>. The return value must be *false* or *true*. Called from Array, Map, and Set methods to test value equality ignoring differences among members of the zero cohort (e.g., *-0* and *+0*). May not throw an exception.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              _T_::bitwiseAND(x,&nbsp;y)
+            </td>
+            <td>
+              A specification function invoked when applying <emu-xref href="#sec-binary-bitwise-operators">binary bitwise AND operator</emu-xref>. Called by the <emu-xref href="#sec-binary-bitwise-operators-runtime-semantics-evaluation">Binary Bitwise Operators</emu-xref> algorithm for `x &amp; y`.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              _T_::bitwiseXOR(x,&nbsp;y)
+            </td>
+            <td>
+              A specification function invoked when applying <emu-xref href="#sec-binary-bitwise-operators">binary bitwise XOR operator</emu-xref>. Called by the <emu-xref href="#sec-binary-bitwise-operators-runtime-semantics-evaluation">Binary Bitwise Operators</emu-xref> algorithm for `x ^ y`.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              _T_::bitwiseOR(x,&nbsp;y)
+            </td>
+            <td>
+              A specification function invoked when applying <emu-xref href="#sec-binary-bitwise-operators">binary bitwise OR operator</emu-xref>. Called by the <emu-xref href="#sec-binary-bitwise-operators-runtime-semantics-evaluation">Binary Bitwise Operators</emu-xref> algorithm for `x | y`.
+            </td>
+          </tr>
+          </tbody>
+        </table>
+      </emu-table>
+      <p>The _T_::unit value and _T_::_op_ operations are not a part of the ECMAScript language; they are defined here solely to aid the specification of the semantics of the ECMAScript language. Other abstract operations are defined throughout this specification.</p>
+      <p>Because the numeric types are in general not convertible without loss of precision or truncation, the ECMAScript language provides no implicit conversion among these types. Programmers must explicitly call `Number` and `BigInt` functions to convert among types when calling a function which requires another type.</p>
       <emu-note>
-        <p>The bit pattern that might be observed in an ArrayBuffer (see <emu-xref href="#sec-arraybuffer-objects"></emu-xref>) or a SharedArrayBuffer (see <emu-xref href="#sec-sharedarraybuffer-objects"></emu-xref>) after a Number value has been stored into it is not necessarily the same as the internal representation of that Number value used by the ECMAScript implementation.</p>
+        <p>The first and subsequent editions of ECMAScript have provided, for certain operators, implicit numeric conversions that could lose precision or truncate. These legacy implicit conversions are maintained for backward compatibility, but not provided for BigInt in order to minimize opportunity for programmer error, and to leave open the option of generalized <em>value types</em> in a future edition.</p>
       </emu-note>
-      <p>There are two other special values, called *positive Infinity* and *negative Infinity*. For brevity, these values are also referred to for expository purposes by the symbols *+&infin;* and *-&infin;*, respectively. (Note that these two infinite Number values are produced by the program expressions `+Infinity` (or simply `Infinity`) and `-Infinity`.)</p>
-      <p>The other 18437736874454810624 (that is, <emu-eqn>2<sup>64</sup> - 2<sup>53</sup></emu-eqn>) values are called the finite numbers. Half of these are positive numbers and half are negative numbers; for every finite positive Number value there is a corresponding negative value having the same magnitude.</p>
-      <p>Note that there is both a *positive zero* and a *negative zero*. For brevity, these values are also referred to for expository purposes by the symbols *+0* and *-0*, respectively. (Note that these two different zero Number values are produced by the program expressions `+0` (or simply `0`) and `-0`.)</p>
-      <p>The 18437736874454810622 (that is, <emu-eqn>2<sup>64</sup> - 2<sup>53</sup> - 2</emu-eqn>) finite nonzero values are of two kinds:</p>
-      <p>18428729675200069632 (that is, <emu-eqn>2<sup>64</sup> - 2<sup>54</sup></emu-eqn>) of them are normalized, having the form</p>
-      <div class="math-display">
-        _s_ &times; _m_ &times; 2<sup>_e_</sup>
-      </div>
-      <p>where _s_ is +1 or -1, _m_ is a positive integer less than 2<sup>53</sup> but not less than 2<sup>52</sup>, and _e_ is an integer ranging from -1074 to 971, inclusive.</p>
-      <p>The remaining 9007199254740990 (that is, <emu-eqn>2<sup>53</sup> - 2</emu-eqn>) values are denormalized, having the form</p>
-      <div class="math-display">
-        _s_ &times; _m_ &times; 2<sup>_e_</sup>
-      </div>
-      <p>where _s_ is +1 or -1, _m_ is a positive integer less than 2<sup>52</sup>, and _e_ is -1074.</p>
-      <p>Note that all the positive and negative integers whose magnitude is no greater than 2<sup>53</sup> are representable in the Number type (indeed, the integer 0 has two representations, *+0* and *-0*).</p>
-      <p>A finite number has an <em>odd significand</em> if it is nonzero and the integer _m_ used to express it (in one of the two forms shown above) is odd. Otherwise, it has an <em>even significand</em>.</p>
-      <p>In this specification, the phrase &ldquo;the Number value for _x_&rdquo; where _x_ represents an exact real mathematical quantity (which might even be an irrational number such as &pi;) means a Number value chosen in the following manner. Consider the set of all finite values of the Number type, with *-0* removed and with two additional values added to it that are not representable in the Number type, namely 2<sup>1024</sup> (which is <emu-eqn>+1 &times; 2<sup>53</sup> &times; 2<sup>971</sup></emu-eqn>) and <emu-eqn>-2<sup>1024</sup></emu-eqn> (which is <emu-eqn>-1 &times; 2<sup>53</sup> &times; 2<sup>971</sup></emu-eqn>). Choose the member of this set that is closest in value to _x_. If two values of the set are equally close, then the one with an even significand is chosen; for this purpose, the two extra values 2<sup>1024</sup> and <emu-eqn>-2<sup>1024</sup></emu-eqn> are considered to have even significands. Finally, if 2<sup>1024</sup> was chosen, replace it with *+&infin;*; if <emu-eqn>-2<sup>1024</sup></emu-eqn> was chosen, replace it with *-&infin;*; if *+0* was chosen, replace it with *-0* if and only if _x_ is less than zero; any other chosen value is used unchanged. The result is the Number value for _x_. (This procedure corresponds exactly to the behaviour of the IEEE 754-2008 roundTiesToEven mode.)</p>
-      <p>Some ECMAScript operators deal only with integers in specific ranges such as <emu-eqn>-2<sup>31</sup></emu-eqn> through <emu-eqn>2<sup>31</sup> - 1</emu-eqn>, inclusive, or in the range 0 through <emu-eqn>2<sup>16</sup> - 1</emu-eqn>, inclusive. These operators accept any value of the Number type but first convert each such value to an integer value in the expected range. See the descriptions of the numeric conversion operations in <emu-xref href="#sec-type-conversion"></emu-xref>.</p>
+
+      <emu-clause id="sec-ecmascript-language-types-number-type">
+        <h1>The Number Type</h1>
+        <p>The Number type has exactly 18437736874454810627 (that is, <emu-eqn>2<sup>64</sup> - 2<sup>53</sup> + 3</emu-eqn>) values, representing the double-precision 64-bit binary format IEEE 754-2008 values as specified in the IEEE Standard for Floating-Point Arithmetic, except that the 9007199254740990 (that is, <emu-eqn>2<sup>53</sup> - 2</emu-eqn>) distinct &ldquo;Not-a-Number&rdquo; values of the IEEE Standard are represented in ECMAScript as a single special *NaN* value. (Note that the *NaN* value is produced by the program expression `NaN`.) In some implementations, external code might be able to detect a difference between various Not-a-Number values, but such behaviour is implementation-dependent; to ECMAScript code, all *NaN* values are indistinguishable from each other.</p>
+        <emu-note>
+          <p>The bit pattern that might be observed in an ArrayBuffer (see <emu-xref href="#sec-arraybuffer-objects"></emu-xref>) or a SharedArrayBuffer (see <emu-xref href="#sec-sharedarraybuffer-objects"></emu-xref>) after a Number value has been stored into it is not necessarily the same as the internal representation of that Number value used by the ECMAScript implementation.</p>
+        </emu-note>
+        <p>There are two other special values, called *positive Infinity* and *negative Infinity*. For brevity, these values are also referred to for expository purposes by the symbols *+&infin;* and *-&infin;*, respectively. (Note that these two infinite Number values are produced by the program expressions `+Infinity` (or simply `Infinity`) and `-Infinity`.)</p>
+        <p>The other 18437736874454810624 (that is, <emu-eqn>2<sup>64</sup> - 2<sup>53</sup></emu-eqn>) values are called the finite numbers. Half of these are positive numbers and half are negative numbers; for every finite positive Number value there is a corresponding negative value having the same magnitude.</p>
+        <p>Note that there is both a *positive zero* and a *negative zero*. For brevity, these values are also referred to for expository purposes by the symbols *+0* and *-0*, respectively. (Note that these two different zero Number values are produced by the program expressions `+0` (or simply `0`) and `-0`.)</p>
+        <p>The 18437736874454810622 (that is, <emu-eqn>2<sup>64</sup> - 2<sup>53</sup> - 2</emu-eqn>) finite nonzero values are of two kinds:</p>
+        <p>18428729675200069632 (that is, <emu-eqn>2<sup>64</sup> - 2<sup>54</sup></emu-eqn>) of them are normalized, having the form</p>
+        <div class="math-display">
+          _s_ &times; _m_ &times; 2<sup>_e_</sup>
+        </div>
+        <p>where _s_ is +1 or -1, _m_ is a positive integer less than 2<sup>53</sup> but not less than 2<sup>52</sup>, and _e_ is an integer ranging from -1074 to 971, inclusive.</p>
+        <p>The remaining 9007199254740990 (that is, <emu-eqn>2<sup>53</sup> - 2</emu-eqn>) values are denormalized, having the form</p>
+        <div class="math-display">
+          _s_ &times; _m_ &times; 2<sup>_e_</sup>
+        </div>
+        <p>where _s_ is +1 or -1, _m_ is a positive integer less than 2<sup>52</sup>, and _e_ is -1074.</p>
+        <p>Note that all the positive and negative integers whose magnitude is no greater than 2<sup>53</sup> are representable in the Number type (indeed, the integer 0 has two representations, *+0* and *-0*).</p>
+        <p>A finite number has an <em>odd significand</em> if it is nonzero and the integer _m_ used to express it (in one of the two forms shown above) is odd. Otherwise, it has an <em>even significand</em>.</p>
+        <p>In this specification, the phrase &ldquo;the Number value for _x_&rdquo; where _x_ represents an exact real mathematical quantity (which might even be an irrational number such as &pi;) means a Number value chosen in the following manner. Consider the set of all finite values of the Number type, with *-0* removed and with two additional values added to it that are not representable in the Number type, namely 2<sup>1024</sup> (which is <emu-eqn>+1 &times; 2<sup>53</sup> &times; 2<sup>971</sup></emu-eqn>) and <emu-eqn>-2<sup>1024</sup></emu-eqn> (which is <emu-eqn>-1 &times; 2<sup>53</sup> &times; 2<sup>971</sup></emu-eqn>). Choose the member of this set that is closest in value to _x_. If two values of the set are equally close, then the one with an even significand is chosen; for this purpose, the two extra values 2<sup>1024</sup> and <emu-eqn>-2<sup>1024</sup></emu-eqn> are considered to have even significands. Finally, if 2<sup>1024</sup> was chosen, replace it with *+&infin;*; if <emu-eqn>-2<sup>1024</sup></emu-eqn> was chosen, replace it with *-&infin;*; if *+0* was chosen, replace it with *-0* if and only if _x_ is less than zero; any other chosen value is used unchanged. The result is the Number value for _x_. (This procedure corresponds exactly to the behaviour of the IEEE 754-2008 roundTiesToEven mode.)</p>
+        <p>Some ECMAScript operators deal only with integers in specific ranges such as <emu-eqn>-2<sup>31</sup></emu-eqn> through <emu-eqn>2<sup>31</sup> - 1</emu-eqn>, inclusive, or in the range 0 through <emu-eqn>2<sup>16</sup> - 1</emu-eqn>, inclusive. These operators accept any value of the Number type but first convert each such value to an integer value in the expected range. See the descriptions of the numeric conversion operations in <emu-xref href="#sec-type-conversion"></emu-xref>.</p>
+      </emu-clause>
+
+      <emu-clause id="sec-ecmascript-language-types-bigint-type">
+        <h1>The BigInt Type</h1>
+        <p>The BigInt type represents a mathematical integer value. The value may be any size and is not limited to a particular bit-width. Generally, where not otherwise noted, operations are designed to return exact mathematically-based answers. For binary operations, BigInts act as two's complement binary strings, with negative numbers treated as having bits set infinitely to the left.</p>
+
+        <p>The BigInt::unit value is *1n*.</p>
+
+        <emu-clause id="sec-numeric-types-bigint-unaryMinus">
+          <h1>BigInt::unaryMinus (_x_)</h1>
+          <p>The abstract operation BigInt::unaryMinus with an argument _x_ of BigInt type returns the result of negating _x_.</p>
+          <emu-note>There is only one *0n* value; `-0n` is the same as *0n*.</emu-note>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-bigint-bitwiseNOT">
+          <h1>BigInt::bitwiseNOT (_x_)</h1>
+          <p>The abstract operation BigInt::bitwiseNOT with an argument _x_ of BigInt type returns the one's complement of _x_; that is, -_x_ - 1.</p>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-bigint-exponentiate">
+          <h1>BigInt::exponentiate (_base_, _exponent_)</h1>
+          <emu-alg>
+            1. If _exponent_ &lt; 0, throw a *RangeError* exception.
+            1. If _base_ is *0n* and _exponent_ is *0n*, return *1n*.
+            1. Return a BigInt representing the mathematical value of _base_ raised to the power _exponent_.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-bigint-multiply">
+          <h1>BigInt::multiply (_x_, _y_)</h1>
+          <p>The abstract operation BigInt::multiply with two arguments _x_ and _y_ of BigInt type returns a BigInt representing the result of multiplying _x_ and _y_.</p>
+          <emu-note>Even if the result has a much larger bit width than the input, the exact mathematical answer is given.</emu-note>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-bigint-divide">
+          <h1>BigInt::divide (_x_, _y_)</h1>
+          <emu-alg>
+            1. If _y_ is *0n*, throw a *RangeError* exception.
+            1. Let _quotient_ be the mathematical value of _x_ divided by _y_.
+            1. Return a BigInt representing _quotient_ rounded towards 0 to the next integral value.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-bigint-remainder">
+          <h1>BigInt::remainder (_n_, _d_)</h1>
+          <emu-alg>
+            1. If _d_ is *0n*, throw a *RangeError* exception.
+            1. If _n_ is *0n*, return *0n*.
+            1. Let _r_ be the BigInt defined by the mathematical relation _r_ = _n_ - (_d_ &times; _q_) where _q_ is a BigInt that is negative only if _n_/_d_ is negative and positive only if _n_/_d_ is positive, and whose magnitude is as large as possible without exceeding the magnitude of the true mathematical quotient of _n_ and _d_.
+            1. Return _r_.
+          </emu-alg>
+          <emu-note>The sign of the result equals the sign of the dividend.</emu-note>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-bigint-add">
+          <h1>BigInt::add (_x_, _y_)</h1>
+          <p>The abstract operation BigInt::add with two arguments _x_ and _y_ of BigInt type returns a BigInt representing the sum of _x_ and _y_.</p>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-bigint-subtract">
+          <h1>BigInt::subtract (_x_, _y_)</h1>
+          <p>The abstract operation BigInt::subtract with two arguments _x_ and _y_ of BigInt type returns the BigInt representing the difference _x_ minus _y_.</p>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-bigint-leftShift">
+          <h1>BigInt::leftShift (_x_, _y_)</h1>
+          <p>The abstract operation BigInt::leftShift with two arguments _x_ and _y_ of BigInt:</p>
+          <emu-alg>
+            1. If _y_ &lt; 0, then
+              1. Return a BigInt representing _x_ &divide; 2<sup>-_y_</sup>, rounding down to the nearest integer, including for negative numbers.
+            1. Return a BigInt representing _x_ &times; 2<sup>_y_</sup>.
+          </emu-alg>
+          <emu-note>Semantics here should be equivalent to a bitwise shift, treating the BigInt as an infinite length string of binary two's complement digits.</emu-note>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-bigint-signedRightShift">
+          <h1>BigInt::signedRightShift (_x_, _y_)</h1>
+          <p>The abstract operation BigInt::signedRightShift with arguments _x_ and _y_ of type BigInt:</p>
+          <emu-alg>
+            1. Return BigInt::leftShift(_x_, -_y_).
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-bigint-unsignedRightShift">
+          <h1>BigInt::unsignedRightShift (_x_, _y_)</h1>
+          <p>The abstract operation BigInt::unsignedRightShift with two arguments _x_ and _y_ of type BigInt:</p>
+          <emu-alg>
+            1. Throw a *TypeError* exception.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-bigint-lessThan">
+          <h1>BigInt::lessThan (_x_, _y_)</h1>
+          <p>The abstract operation BigInt::lessThan with two arguments _x_ and _y_ of BigInt type returns *true* if _x_ is less than _y_ and *false* otherwise.</p>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-bigint-equal">
+          <h1>BigInt::equal (_x_, _y_)</h1>
+          <p>The abstract operation BigInt::equal with two arguments _x_ and _y_ of BigInt type returns *true* if _x_ and _y_ have the same mathematical integer value and *false* otherwise.</p>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-bigint-sameValue">
+          <h1>BigInt::sameValue (_x_, _y_)</h1>
+          <p>The abstract operation BigInt::sameValue with two arguments _x_ and _y_ of BigInt type:</p>
+          <emu-alg>
+            1. Return BigInt::equal(_x_, _y_).
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-bigint-sameValueZero">
+          <h1>BigInt::sameValueZero (_x_, _y_)</h1>
+          <p>The abstract operation BigInt::sameValueZero with two arguments _x_ and _y_ of BigInt type:</p>
+          <emu-alg>
+            1. Return BigInt::equal(_x_, _y_).
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-bitwise-op">
+          <h1>BitwiseOp(_op_, _x_, _y_)</h1>
+          <emu-alg>
+            1. Let _result_ be 0.
+            1. Let _shift_ be 0.
+            1. Repeat, until (_x_ = 0 or _x_ = -1) and (_y_ = 0 or _y_ = -1),
+              1. Let _xDigit_ be _x_ modulo 2.
+              1. Let _yDigit_ be _y_ modulo 2.
+              1. Let _result_ be _result_ + 2<sup>_shift_</sup> &times; _op_(_xDigit_, _yDigit_).
+              1. Let _shift_ be _shift_ + 1.
+              1. Let _x_ be (_x_ - _xDigit_) / 2.
+              1. Let _y_ be (_y_ - _yDigit_) / 2.
+            1. If _op_(_x_ modulo 2, _y_ modulo 2) &ne; 0, then
+              1. Let _result_ be _result_ - 2<sup>_shift_</sup>. NOTE: This extends the sign.
+            1. Return _result_.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-bigint-bitwiseAND">
+          <h1>BigInt::bitwiseAND (_x_, _y_)</h1>
+          <emu-alg>
+            1. Return BitwiseOp(`&amp;`, _x_, _y_).
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-bigint-bitwiseXOR">
+          <h1>BigInt::bitwiseXOR (_x_, _y_)</h1>
+          <emu-alg>
+            1. Return BitwiseOp(`^`, _x_, _y_).
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-bigint-bitwiseOR">
+          <h1>BigInt::bitwiseOR (_x_, _y_)</h1>
+          <emu-alg>
+            1. Return BitwiseOp(`|`, _x_, _y_).
+          </emu-alg>
+        </emu-clause>
+      </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-object-type">

--- a/spec.html
+++ b/spec.html
@@ -1287,6 +1287,193 @@
         <p>A finite number has an <em>odd significand</em> if it is nonzero and the integer _m_ used to express it (in one of the two forms shown above) is odd. Otherwise, it has an <em>even significand</em>.</p>
         <p>In this specification, the phrase &ldquo;the Number value for _x_&rdquo; where _x_ represents an exact real mathematical quantity (which might even be an irrational number such as &pi;) means a Number value chosen in the following manner. Consider the set of all finite values of the Number type, with *-0* removed and with two additional values added to it that are not representable in the Number type, namely 2<sup>1024</sup> (which is <emu-eqn>+1 &times; 2<sup>53</sup> &times; 2<sup>971</sup></emu-eqn>) and <emu-eqn>-2<sup>1024</sup></emu-eqn> (which is <emu-eqn>-1 &times; 2<sup>53</sup> &times; 2<sup>971</sup></emu-eqn>). Choose the member of this set that is closest in value to _x_. If two values of the set are equally close, then the one with an even significand is chosen; for this purpose, the two extra values 2<sup>1024</sup> and <emu-eqn>-2<sup>1024</sup></emu-eqn> are considered to have even significands. Finally, if 2<sup>1024</sup> was chosen, replace it with *+&infin;*; if <emu-eqn>-2<sup>1024</sup></emu-eqn> was chosen, replace it with *-&infin;*; if *+0* was chosen, replace it with *-0* if and only if _x_ is less than zero; any other chosen value is used unchanged. The result is the Number value for _x_. (This procedure corresponds exactly to the behaviour of the IEEE 754-2008 roundTiesToEven mode.)</p>
         <p>Some ECMAScript operators deal only with integers in specific ranges such as <emu-eqn>-2<sup>31</sup></emu-eqn> through <emu-eqn>2<sup>31</sup> - 1</emu-eqn>, inclusive, or in the range 0 through <emu-eqn>2<sup>16</sup> - 1</emu-eqn>, inclusive. These operators accept any value of the Number type but first convert each such value to an integer value in the expected range. See the descriptions of the numeric conversion operations in <emu-xref href="#sec-type-conversion"></emu-xref>.</p>
+
+        <p>The Number::unit value is *1*.</p>
+
+        <emu-clause id="sec-numeric-types-number-unaryMinus">
+          <h1>Number::unaryMinus (_x_)</h1>
+          
+          <emu-alg>
+            1. If _x_ is *NaN*, return *NaN*.
+            1. Return the result of negating _x_; that is, compute a Number with the same magnitude but opposite sign.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-number-bitwiseNOT">
+          <h1>Number::bitwiseNOT (_x_)</h1>
+
+          <emu-alg>
+            1. Let _oldValue_ be ? ToInt32(? _x_).
+            1. Return the result of applying bitwise complement to _oldValue_. The result is a signed 32-bit integer.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-number-exponentiate">
+          <h1>Number::exponentiate (_base_, _exponent_)</h1>
+
+          <emu-alg>
+            1. Return the result of <emu-xref href="#sec-applying-the-exp-operator" title>Applying the ** operator</emu-xref> with _base_ and _exponent_ as specified in <emu-xref href="#sec-applying-the-exp-operator"></emu-xref>.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-number-multiply">
+          <h1>Number::multiply (_x_, _y_)</h1>
+
+          <emu-alg>
+            1. Return the result of <emu-xref href="#sec-applying-the-mul-operator" title>Applying the * operator</emu-xref> to _x_ and _y_ as specified in <emu-xref href="#sec-applying-the-mul-operator"></emu-xref>.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-number-divide">
+          <h1>Number::divide (_x_, _y_)</h1>
+          <emu-alg>
+            1. Return the result of <emu-xref href="#sec-applying-the-div-operator" title>Applying the / operator</emu-xref> to _x_ and _y_ as specified in <emu-xref href="#sec-applying-the-div-operator"></emu-xref>.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-number-remainder">
+          <h1>Number::remainder (_n_, _d_)</h1>
+          <emu-alg>
+            1. Return the result of <emu-xref href="#sec-applying-the-mod-operator" title>Applying the % operator</emu-xref> to _n_ and _d_ as specified in <emu-xref href="#sec-applying-the-mod-operator"></emu-xref>..
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-number-add">
+          <h1>Number::add (_x_, _y_)</h1>
+
+          <emu-alg>
+            1. Return the result of applying the addition operation to _x_ and _y_. See the Note on <emu-xref href="#sec-applying-the-additive-operators-to-numbers"></emu-xref>.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-number-subtract">
+          <h1>Number::subtract (_x_, _y_)</h1>
+
+          <emu-alg>
+            1. Return the result of applying the subtraction operation to _x_ and _y_. See the Note on <emu-xref href="#sec-applying-the-additive-operators-to-numbers"></emu-xref>.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-number-leftShift">
+          <h1>Number::leftShift (_x_, _y_)</h1>
+
+          <emu-alg>
+            1. Let _lnum_ be ? ToInt32(_x_).
+            1. Let _rnum_ be ? ToUint32(_y_).
+            1. Let _shiftCount_ be the result of masking out all but the least significant 5 bits of _rnum_, that is, compute _rnum_ &amp; 0x1F.
+            1. Return the result of left shifting _lnum_ by _shiftCount_ bits. The result is a signed 32-bit integer.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-number-signedRightShift">
+          <h1>Number::signedRightShift (_x_, _y_)</h1>
+
+          <emu-alg>
+            1. Let _lnum_ be ? ToInt32(_x_).
+            1. Let _rnum_ be ? ToUint32(_y_).
+            1. Let _shiftCount_ be the result of masking out all but the least significant 5 bits of _rnum_, that is, compute _rnum_ &amp; 0x1F.
+            1. Return the result of performing a sign-extending right shift of _lnum_ by _shiftCount_ bits. The most significant bit is propagated. The result is a signed 32-bit integer.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-number-unsignedRightShift">
+          <h1>Number::unsignedRightShift (_x_, _y_)</h1>
+
+          <emu-alg>
+            1. Let _lnum_ be ? ToInt32(_x_).
+            1. Let _rnum_ be ? ToUint32(_y_).
+            1. Let _shiftCount_ be the result of masking out all but the least significant 5 bits of _rnum_, that is, compute _rnum_ &amp; 0x1F.
+            1. Return the result of performing a zero-filling right shift of _lnum_ by _shiftCount_ bits. Vacated bits are filled with zero. The result is an unsigned 32-bit integer.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-number-lessThan">
+          <h1>Number::lessThan (_x_, _y_)</h1>
+
+          <emu-alg>
+            1. If _x_ is *NaN*, return *undefined*.
+            1. If _y_ is *NaN*, return *undefined*.
+            1. If _x_ and _y_ are the same Number value, return *false*.
+            1. If _x_ is *+0* and _y_ is *-0*, return *false*.
+            1. If _x_ is *-0* and _y_ is *+0*, return *false*.
+            1. If _x_ is *+&infin;*, return *false*.
+            1. If _y_ is *+&infin;*, return *true*.
+            1. If _y_ is *-&infin;*, return *false*.
+            1. If _x_ is *-&infin;*, return *true*.
+            1. If the mathematical value of _x_ is less than the mathematical value of _y_ &mdash;note that these mathematical values are both finite and not both zero&mdash;return *true*. Otherwise, return *false*.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-number-equal">
+          <h1>Number::equal (_x_, _y_)</h1>
+
+          <emu-alg>
+            1. If _x_ is *NaN*, return *false*.
+            1. If _y_ is *NaN*, return *false*.
+            1. If _x_ is the same Number value as _y_, return *true*.
+            1. If _x_ is *+0* and _y_ is *-0*, return *true*.
+            1. If _x_ is *-0* and _y_ is *+0*, return *true*.
+            1. Return *false*.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-number-sameValue">
+          <h1>Number::sameValue (_x_, _y_)</h1>
+
+          <emu-alg>
+            1. If _x_ is *NaN* and _y_ is *NaN*, return *true*.
+            1. If _x_ is *+0* and _y_ is *-0*, return *false*.
+            1. If _x_ is *-0* and _y_ is *+0*, return *false*.
+            1. If _x_ is the same Number value as _y_, return *true*.
+            1. Return *false*.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-number-sameValueZero">
+          <h1>Number::sameValueZero (_x_, _y_)</h1>
+
+          <emu-alg>
+            1. If _x_ is *NaN* and _y_ is *NaN*, return *true*.
+            1. If _x_ is *+0* and _y_ is *-0*, return *true*.
+            1. If _x_ is *-0* and _y_ is *+0*, return *true*.
+            1. If _x_ is the same Number value as _y_, return *true*.
+            1. Return *false*.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-number-bitwise-op">
+          <h1>NumberBitwiseOp(_op_, _x_, _y_)</h1>
+
+          <emu-alg>
+            1. Let _lnum_ be ? ToInt32(_x_).
+            1. Let _rnum_ be ? ToUint32(_y_).
+            1. Return the result of applying the bitwise operator _op_ to _lnum_ and _rnum_. The result is a signed 32-bit integer.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-number-bitwiseAND">
+          <h1>Number::bitwiseAND (_x_, _y_)</h1>
+
+          <emu-alg>
+            1. Return NumberBitwiseOp(`&amp;`, _x_, _y_).
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-number-bitwiseXOR">
+          <h1>Number::bitwiseXOR (_x_, _y_)</h1>
+
+          <emu-alg>
+            1. Return NumberBitwiseOp(`^`, _x_, _y_).
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-number-bitwiseOR">
+          <h1>Number::bitwiseOR (_x_, _y_)</h1>
+
+          <emu-alg>
+            1. Return NumberBitwiseOp(`|`, _x_, _y_).
+          </emu-alg>
+        </emu-clause>
       </emu-clause>
 
       <emu-clause id="sec-ecmascript-language-types-bigint-type">


### PR DESCRIPTION
Those commits are adding `BigInt` numeric type and operations to ecma262 spec text. It is also adding `Number::operations` descriptions.