### PR TITLE
Editorial: Update About this Specification wording

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -76,7 +76,7 @@
   </ul>
   <p>Refer to the <emu-xref href="#sec-colophon">colophon</emu-xref> for more information on how this document is created.</p>
   <h1>About this Specification</h1>
-  <p>This document at <a href=".">https://tc39.es/ecma262/</a> is the most accurate up-to-date ECMAScript specification. It contains the content of the most recent yearly snapshot plus any <a href="https://github.com/tc39/proposals/blob/master/finished-proposals.md">finished proposals</a> (those that have reached Stage&nbsp;4 in the <a href="https://tc39.es/process-document/">proposal process</a> and thus are implemented in several implementations and will be in the next practical revision) since that snapshot was taken.</p>
+  <p>This document at <a href=".">https://tc39.es/ecma262/</a> is the most accurate and up-to-date ECMAScript specification. It contains the content of the most recent yearly snapshot plus any <a href="https://github.com/tc39/proposals/blob/master/finished-proposals.md">finished proposals</a> (those that have reached Stage&nbsp;4 in the <a href="https://tc39.es/process-document/">proposal process</a> and thus are implemented in several implementations and will be in the next practical revision) since that snapshot was taken.</p>
 </div>
 <emu-intro id="sec-intro">
   <h1>Introduction</h1>


### PR DESCRIPTION
This change updates the wording of the first sentence in the "About this Specification" section to read:

> This document at https://tc39.es/ecma262/ is the most accurate and  up-to-date ECMAScript specification.

Without this change, it just reads “the most accurate up-to-date”, without the word “and”.